### PR TITLE
Add input for environment variables

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,6 +4,10 @@ on:
   push:
     paths-ignore:
       - README.md
+  pull_request:
+    paths-ignore:
+      - README.md
+  
 
 jobs:
   test:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,6 +23,7 @@ jobs:
         image: 'sample-bash-app'
         path: 'samples/apps/bash-script/'
         builder: 'cnbs/sample-builder:bionic'
+        env: 'HELLO=WORLD FOO=BAR BAZ'
       id: build
     
     - name: Show build command

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,6 +23,10 @@ jobs:
         image: 'sample-bash-app'
         path: 'samples/apps/bash-script/'
         builder: 'cnbs/sample-builder:bionic'
+      id: build
+    
+    - name: Show build command
+      run: echo ${{ steps.build.outputs.command }}
 
     - name: Check the built image
       run: docker image ls | grep sample-bash-app

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,8 @@
 FROM docker:19.03-dind
 
-ENV VERSION=v0.11.0
+ENV VERSION=v0.12.0
 
-RUN apk add --update --no-cache curl && \
+RUN apk add --update --no-cache curl bash && \
     curl -LO https://github.com/buildpacks/pack/releases/download/${VERSION}/pack-${VERSION}-linux.tgz && \
     tar xfz pack-${VERSION}-linux.tgz && \
     mv pack /usr/bin/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM docker:19.03-dind
 
-ENV VERSION=v0.12.0
+ENV VERSION=v0.11.0
 
 RUN apk add --update --no-cache curl bash && \
     curl -LO https://github.com/buildpacks/pack/releases/download/${VERSION}/pack-${VERSION}-linux.tgz && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM docker:19.03-dind
 
-ENV VERSION=v0.11.0
+ENV VERSION=v0.12.0
 
 RUN apk add --update --no-cache curl bash && \
     curl -LO https://github.com/buildpacks/pack/releases/download/${VERSION}/pack-${VERSION}-linux.tgz && \

--- a/README.md
+++ b/README.md
@@ -18,14 +18,18 @@ on: [push]
         tag: '1.0.0'
         path: 'path/to/foo-app/'
         builder: 'gcr.io/paketo-buildpacks/builder:base'
+        env: 'HELLO=WORLD FOO=BAR BAZ'
 
     - name: Push image
 ```
 
-> buildpacks v0.11.0 will be run.
+> buildpacks v0.12.0 will be executed.
 
 ## Inputs
 - `image` : (required) Name of container image.
 - `tag` : (optional) Tag of container image. Default `latest`
 - `path` : (required) Path to target application.
 - `builder` : (required) Builder to use.
+- `env` : (optional) Environment variables, space separated.
+
+> See "[Cloud Native Buildpack Documentation · Environment variables](https://buildpacks.io/docs/app-developer-guide/environment-variables/)" for environment valiables.

--- a/action.yml
+++ b/action.yml
@@ -18,6 +18,15 @@ inputs:
   builder:
     description: 'Builder to use'
     required: true
+  env:
+    description: 'Build-time environment variables'
+    required: false
+  env_file:
+    description: 'Build-time environment variable file'
+    required: false
+outputs:
+  command:
+    description: 'build command executed'
 
 runs:
   using: 'docker'

--- a/action.yml
+++ b/action.yml
@@ -21,9 +21,6 @@ inputs:
   env:
     description: 'Build-time environment variables'
     required: false
-  env_file:
-    description: 'Build-time environment variable file'
-    required: false
 outputs:
   command:
     description: 'build command executed'

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,4 +1,4 @@
-#!/bin/sh -l
+#!/bin/bash -l
 
 set -e
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -4,7 +4,7 @@ set -e
 
 env_str=""
 if [ -n "$INPUT_ENV" ]; then
-  read -r -a arr <<< "$INPUT_ENV"
+  arr=(${INPUT_ENV})
 
   for e in "${arr[@]}"
   do

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -14,6 +14,8 @@ if [ -n "$INPUT_ENV" ]; then
 fi
 
 command="pack build ${INPUT_IMAGE}:${INPUT_TAG} ${env_str} --path ${INPUT_PATH} --builder ${INPUT_BUILDER}"
+echo $command
+
 echo "::set-output name=command::$command"
 
 sh -c $command

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -12,9 +12,9 @@ if [ -n "$INPUT_ENV" ]; then
   done
 fi
 
-command="pack build ${INPUT_IMAGE}:${INPUT_TAG} ${env_str} --path ${INPUT_PATH} --builder ${INPUT_BUILDER}"
+command="'"'pack build ${INPUT_IMAGE}:${INPUT_TAG} ${env_str} --path ${INPUT_PATH} --builder ${INPUT_BUILDER}'"'"
 echo $command
 
 echo "::set-output name=command::$command"
 
-sh -c "pack build ${INPUT_IMAGE}:${INPUT_TAG} ${env_str} --path ${INPUT_PATH} --builder ${INPUT_BUILDER}"
+sh -c $command

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -9,7 +9,7 @@ if [ -n "$INPUT_ENV" ]; then
   for e in "${arr[@]}"
   do
     env_str+=" --env "
-    env_str*='"'$e'"'
+    env_str*='''$e'''
   done
 fi
 echo ${env_str}

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -9,7 +9,7 @@ if [ -n "$INPUT_ENV" ]; then
   for e in "${arr[@]}"
   do
     env_str+=" --env "
-    env_str+='''$e'''
+    env_str+='"'$e'"'
   done
 fi
 echo ${env_str}

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -2,4 +2,18 @@
 
 set -e
 
-sh -c "pack build ${INPUT_IMAGE}:${INPUT_TAG} --path ${INPUT_PATH} --builder ${INPUT_BUILDER}"
+env_str=""
+if [ -n "$INPUT_ENV" ]; then
+  read -r -a arr <<< "$INPUT_ENV"
+
+  for e in "${arr[@]}"
+  do
+    env_str+=" --env "
+    env_str+='"'$e'"'
+  done
+fi
+
+command="pack build ${INPUT_IMAGE}:${INPUT_TAG} ${env_str} --path ${INPUT_PATH} --builder ${INPUT_BUILDER}"
+echo "::set-output name=command::$command"
+
+sh -c $command

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -12,9 +12,9 @@ if [ -n "$INPUT_ENV" ]; then
   done
 fi
 
-command="pack build ${INPUT_IMAGE}:${INPUT_TAG} --path ${INPUT_PATH} --builder ${INPUT_BUILDER}"
+command="pack build ${INPUT_IMAGE}:${INPUT_TAG} ${env_str} --path ${INPUT_PATH} --builder ${INPUT_BUILDER}"
 echo $command
 
 echo "::set-output name=command::$command"
 
-sh -c $command
+sh -c '"'$command'"'

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -8,13 +8,10 @@ if [ -n "$INPUT_ENV" ]; then
 
   for e in "${arr[@]}"
   do
-    env_str+=" --env $e"
+    env_str+=" --env "
+    env_str*='"'$e'"'
   done
 fi
+echo ${env_str}
 
-command="'"'pack build ${INPUT_IMAGE}:${INPUT_TAG} ${env_str} --path ${INPUT_PATH} --builder ${INPUT_BUILDER}'"'"
-echo $command
-
-echo "::set-output name=command::$command"
-
-sh -c $command
+sh -c "pack build ${INPUT_IMAGE}:${INPUT_TAG} ${env_str} --path ${INPUT_PATH} --builder ${INPUT_BUILDER}"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -8,8 +8,7 @@ if [ -n "$INPUT_ENV" ]; then
 
   for e in "${arr[@]}"
   do
-    env_str+=" --env "
-    env_str+='''$e'''
+    env_str+=" --env $e"
   done
 fi
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -9,7 +9,7 @@ if [ -n "$INPUT_ENV" ]; then
   for e in "${arr[@]}"
   do
     env_str+=" --env "
-    env_str+='"'$e'"'
+    env_str+='''$e'''
   done
 fi
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -12,6 +12,7 @@ if [ -n "$INPUT_ENV" ]; then
     env_str+='"'$e'"'
   done
 fi
-echo ${env_str}
+command="pack build ${INPUT_IMAGE}:${INPUT_TAG} ${env_str} --path ${INPUT_PATH} --builder ${INPUT_BUILDER}"
+echo "::set-output name=command::${command}"
 
-sh -c "pack build ${INPUT_IMAGE}:${INPUT_TAG} ${env_str} --path ${INPUT_PATH} --builder ${INPUT_BUILDER}"
+sh -c "${command}"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -17,4 +17,4 @@ echo $command
 
 echo "::set-output name=command::$command"
 
-sh -c '"'$command'"'
+sh -c "pack build ${INPUT_IMAGE}:${INPUT_TAG} ${env_str} --path ${INPUT_PATH} --builder ${INPUT_BUILDER}"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -9,7 +9,7 @@ if [ -n "$INPUT_ENV" ]; then
   for e in "${arr[@]}"
   do
     env_str+=" --env "
-    env_str*='''$e'''
+    env_str+='''$e'''
   done
 fi
 echo ${env_str}

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -12,7 +12,7 @@ if [ -n "$INPUT_ENV" ]; then
   done
 fi
 
-command="pack build ${INPUT_IMAGE}:${INPUT_TAG} ${env_str} --path ${INPUT_PATH} --builder ${INPUT_BUILDER}"
+command="pack build ${INPUT_IMAGE}:${INPUT_TAG} --path ${INPUT_PATH} --builder ${INPUT_BUILDER}"
 echo $command
 
 echo "::set-output name=command::$command"


### PR DESCRIPTION
#4 に対応する PR です。

inputs に `env` を追加して、pack build の --env で渡す環境変数を指定できるようにしました。
`outputs.command` に実際に実行されたコマンドを格納するようにしました。

環境変数の指定は、README の通りです。

pack コマンドのバージョンを 0.12.0 に上げています。
