### PR TITLE
Update pack cli to v0.19.0 and honor `env-files` input

### DIFF
--- a/.env.ci
+++ b/.env.ci
@@ -1,0 +1,1 @@
+EXAMPLE=value

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,8 +27,9 @@ jobs:
         path: 'samples/apps/bash-script/'
         builder: 'cnbs/sample-builder:bionic'
         env: 'HELLO=WORLD FOO=BAR BAZ'
+        env-files: '.env.ci'
       id: build
-    
+
     - name: Show build command
       run: echo ${{ steps.build.outputs.command }}
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,7 +27,7 @@ jobs:
         path: 'samples/apps/bash-script/'
         builder: 'cnbs/sample-builder:bionic'
         env: 'HELLO=WORLD FOO=BAR BAZ'
-        env-files: '.env.ci'
+        env_files: '.env.ci'
       id: build
 
     - name: Show build command

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM docker:20.10.3-dind
 
-ENV VERSION=v0.17.0
+ENV VERSION=v0.19.0
 
 RUN apk add --update --no-cache curl bash && \
     curl -LO https://github.com/buildpacks/pack/releases/download/${VERSION}/pack-${VERSION}-linux.tgz && \

--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ on: [push]
 - `builder` : (required) Builder to use.
 - `buildpacks` : (optional) URLs or Paths to Custom buildpacks, space separated.
 - `env` : (optional) Environment variables, space separated.
+- `env-file` : (optional) Files containing build time environment variables, space separated.
 
 > See "[Cloud Native Buildpack Documentation · Environment variables](https://buildpacks.io/docs/app-developer-guide/environment-variables/)" for environment valiables.
 

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ on: [push]
 - `builder` : (required) Builder to use.
 - `buildpacks` : (optional) URLs or Paths to Custom buildpacks, space separated.
 - `env` : (optional) Environment variables, space separated.
-- `env-file` : (optional) Files containing build time environment variables, space separated.
+- `env-files` : (optional) Files containing build time environment variables, space separated.
 
 > See "[Cloud Native Buildpack Documentation · Environment variables](https://buildpacks.io/docs/app-developer-guide/environment-variables/)" for environment valiables.
 

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ on: [push]
 ## Inputs
 - `image` : (required) Name of container image.
 - `tag` : (optional) Tag of container image. Default `latest`
-- `path` : (required) Path to target application.
+- `path` : (optional) Path to target application, defaults to the current directory.
 - `builder` : (required) Builder to use.
 - `buildpacks` : (optional) URLs or Paths to Custom buildpacks, space separated.
 - `env` : (optional) Environment variables, space separated.

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ on: [push]
 - `builder` : (required) Builder to use.
 - `buildpacks` : (optional) URLs or Paths to Custom buildpacks, space separated.
 - `env` : (optional) Environment variables, space separated.
-- `env-files` : (optional) Files containing build time environment variables, space separated.
+- `env_files` : (optional) Files containing build time environment variables, space separated.
 
 > See "[Cloud Native Buildpack Documentation · Environment variables](https://buildpacks.io/docs/app-developer-guide/environment-variables/)" for environment valiables.
 

--- a/action.yml
+++ b/action.yml
@@ -13,7 +13,7 @@ inputs:
     default: 'latest'
     required: false
   path:
-    description: 'Path to target application'
+    description: 'Path to target application, defaults to the current directory'
     default: '.'
     required: false
   builder:

--- a/action.yml
+++ b/action.yml
@@ -14,7 +14,8 @@ inputs:
     required: false
   path:
     description: 'Path to target application'
-    required: true
+    default: '.'
+    required: false
   builder:
     description: 'Builder to use'
     required: true

--- a/action.yml
+++ b/action.yml
@@ -24,6 +24,9 @@ inputs:
   env:
     description: 'Build-time environment variables'
     required: false
+  env-files:
+    description: 'Read build-time environment variables from these files'
+    required: false
 outputs:
   command:
     description: 'build command executed'

--- a/action.yml
+++ b/action.yml
@@ -24,7 +24,7 @@ inputs:
   env:
     description: 'Build-time environment variables'
     required: false
-  env-files:
+  env_files:
     description: 'Read build-time environment variables from these files'
     required: false
 outputs:

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -12,6 +12,16 @@ if [ -n "$INPUT_ENV" ]; then
   done
 fi
 
+env_files_str=""
+if [ -n "$INPUT_ENV_FILES" ]; then
+  arr=(${INPUT_ENV_FILES})
+  for e in "${arr[@]}"
+  do
+    env_files_str+=" --env-file "
+    env_files_str+='"'$e'"'
+  done
+fi
+
 buildpacks=""
 if [ -n "$INPUT_BUILDPACKS" ]; then
   arr=(${INPUT_BUILDPACKS})
@@ -22,7 +32,7 @@ if [ -n "$INPUT_BUILDPACKS" ]; then
   done
 fi
 
-command="pack build ${INPUT_IMAGE}:${INPUT_TAG} ${env_str} --path ${INPUT_PATH} ${buildpacks} --builder ${INPUT_BUILDER}"
+command="pack build ${INPUT_IMAGE}:${INPUT_TAG} ${env_str} ${env_files_str} --path ${INPUT_PATH} ${buildpacks} --builder ${INPUT_BUILDER}"
 echo "::set-output name=command::${command}"
 
 sh -c "${command}"


### PR DESCRIPTION
This PR upgrades `pack` to v0.19.0.

It also adds a new input to the action: `env_files`

`env_files` is a stringArray and allows users to specify files from which
they want to load build time environment. It feeds into the `env-file` argument
provided by `pack` itself.