### PR TITLE
Add feature to publish the image to the registry

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,7 @@ jobs:
       with:
         image: 'sample-bash-app'
         path: 'samples/apps/bash-script/'
-        builder: 'cnbs/sample-builder:bionic'
+        builder: 'cnbs/sample-builder:alpine'
         env: 'HELLO=WORLD FOO=BAR BAZ'
         env_files: '.env.ci'
       id: build
@@ -35,6 +35,21 @@ jobs:
 
     - name: Check the built image
       run: docker image ls | grep sample-bash-app
+
+    - name: Check publishing
+      uses: ./
+      with:
+        image: 'sample-bash-app'
+        path: 'samples/apps/bash-script/'
+        builder: 'cnbs/sample-builder:alpine'
+        env: 'HELLO=WORLD FOO=BAR BAZ'
+        env_files: '.env.ci'
+        debug_mode: "true"
+        publish: true
+      id: publish
+
+    - name: Check publish argument was present
+      run: echo ${{ steps.publish.outputs.command }} | grep publish
 
   build-maven-app:
     runs-on: ubuntu-latest

--- a/README.md
+++ b/README.md
@@ -33,6 +33,8 @@ on: [push]
 - `buildpacks` : (optional) URLs or Paths to Custom buildpacks, space separated.
 - `env` : (optional) Environment variables, space separated.
 - `env_files` : (optional) Files containing build time environment variables, space separated.
+- `publish` : (optional) Publish the built image (requires docker to be logged in)
+- `debug_mode` : (optional) Only print the command to be run. Will not build container image
 
 > See "[Cloud Native Buildpack Documentation · Environment variables](https://buildpacks.io/docs/app-developer-guide/environment-variables/)" for environment valiables.
 
@@ -53,4 +55,5 @@ on: [push]
         path: 'samples/apps/java-maven/'
         builder: 'cnbs/sample-builder:alpine'
         buildpacks: 'samples/buildpacks/java-maven samples/buildpacks/hello-processes/ cnbs/sample-package:hello-universe'
+        publish: true
 ```

--- a/action.yml
+++ b/action.yml
@@ -28,6 +28,13 @@ inputs:
   env_files:
     description: 'Read build-time environment variables from these files'
     required: false
+  publish:
+    description: 'Publish the resulting image to the registry'
+    required: false
+  debug_mode:
+    description: "Run in debug mode - only output command is set. Don't run the pack command"
+    required: false
+
 outputs:
   command:
     description: 'build command executed'

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -32,7 +32,17 @@ if [ -n "$INPUT_BUILDPACKS" ]; then
   done
 fi
 
-command="pack build ${INPUT_IMAGE}:${INPUT_TAG} ${env_str} ${env_files_str} --path ${INPUT_PATH} ${buildpacks} --builder ${INPUT_BUILDER}"
+publish=""
+if [ -n "$INPUT_PUBLISH" ]; then
+  publish="--publish"
+fi
+
+command="pack build ${INPUT_IMAGE}:${INPUT_TAG} ${env_str} ${env_files_str} --path ${INPUT_PATH} ${buildpacks} --builder ${INPUT_BUILDER} ${publish}"
 echo "command=${command}" >> $GITHUB_OUTPUT
 
-sh -c "${command}"
+if [ "$INPUT_DEBUG_MODE" = "true" ]; then
+  echo "Running in debug mode"
+  echo "command = ${command}"
+else
+  sh -c "${command}"
+fi


### PR DESCRIPTION
Currently this action is not able to publish the image to the registry. 
The pack command however does support publishing the image as well. 
This is done using the `--publish` argument to the pack command. 

This PR adds an additional input `publish`. If this is set, we add the `--publish` argument to the pack command. 

In addition, the existing build image step was failing due to incompatibility with the `cnbs/sample-builder:bionic` buildpack. Moved that to the `alpine` image. 

Finally, also added a `debug_mode` input. This was primarily needed to safely test publishing in the CI workflow. 